### PR TITLE
fix: AltGr + space intended way in symbols_noop

### DIFF
--- a/kanata/deflayer_symbols_noop.kbd
+++ b/kanata/deflayer_symbols_noop.kbd
@@ -8,7 +8,7 @@
   AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
   AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
   AG-z AG-x AG-c AG-v AG-b  XX  AG-n AG-m AG-, AG-. AG-/
-            _              spc            _
+            _             AG-spc          _
 )
 
 ;; vim: set ft=lisp

--- a/kanata/deflayer_symbols_noop_num.kbd
+++ b/kanata/deflayer_symbols_noop_num.kbd
@@ -9,7 +9,7 @@
   AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
   AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
   AG-z AG-x AG-c AG-v AG-b  XX  AG-n AG-m AG-, AG-. AG-/
-            @num           spc            _
+            @num          AG-spc          _
 )
 
 ;; Numrow layer


### PR DESCRIPTION
In symbols_noop mod, AltGr + space output a space but should do an AltGr-space.
e.g. in Bépo should output an  ̀_` (underscore)