### PR TITLE
feat(drivers): Added preliminary Kanata Ergo-L

### DIFF
--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -6,8 +6,7 @@ An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
 
 - Only Azerty-FR is supported as the base keymap at this point.
 - Mac keyboards are not supported at this point.
-- "Useless" right-hand keys are not remapped at this point; they should
-  ideally be remapped to their Qwerty/Ergo-L counterparts.
-- Some exotic characters may be missing, please report bugs.
+- AltGr-Shift layer is not yet implemented.
+- Some other exotic characters may be missing, please report bugs.
 - Layer taps are not supported at this point.
 - Home row mods are not supported at this point.

--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -6,7 +6,8 @@ An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
 
 - Only Azerty-FR is supported as the base keymap at this point.
 - Mac keyboards are not supported at this point.
-- AltGr-Shift layer is not yet implemented.
+- CapsLock can have unexpected behaviour, please report bugs.
+- Dead keys on the AltGr-Shift layer are not yet implemented.
 - Some other exotic characters may be missing, please report bugs.
 - Layer taps are not supported at this point.
 - Home row mods are not supported at this point.

--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -1,0 +1,14 @@
+# Ergo-L Kanata driver
+
+An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
+
+## Caveats
+
+- Only Azerty-FR is supported as the base keymap at this point.
+- Mac keyboards are not supported at this point.
+- "Useless" right-hand keys are not remapped at this point; they should
+  ideally be remapped to their Qwerty/Ergo-L counterparts.
+- Some exotic dead key characters are not yet handled (especially those on
+  the numrow).
+- Layer taps are not supported at this point.
+- Home row mods are not supported at this point.

--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -4,10 +4,27 @@ An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
 
 ## Caveats
 
+- Only Windows is supported at this point; this *doesn’t work* on GNU/Linux
+  (yet?) and is untested on macOS.
 - Only Azerty-FR is supported as the base keymap at this point.
 - Mac keyboards are not supported at this point.
 - CapsLock can have unexpected behaviour, please report bugs.
-- Dead keys on the AltGr-Shift layer are not yet implemented.
+- Not all the dead keys on the AltGr-Shift layer are implemented yet.
 - Some other exotic characters may be missing, please report bugs.
 - Layer taps are not supported at this point.
 - Home row mods are not supported at this point.
+
+## Installation
+
+The easiest way to run this driver is to:
+
+1.  Clone this Git repository (or download a zip snapshot).
+1.  Download `kanata_winIOv2.exe` (*not* `kanata.exe`!) from
+    <https://github.com/jtroo/kanata/releases>.
+1.  Place the downloaded exe in this directory.
+1.  Run the exe.
+
+## Angle mod
+
+This driver supports the angle mod for ISO keyboards; you may enable it by
+editing `kanata.kbd`.

--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -8,7 +8,6 @@ An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
 - Mac keyboards are not supported at this point.
 - "Useless" right-hand keys are not remapped at this point; they should
   ideally be remapped to their Qwerty/Ergo-L counterparts.
-- Some exotic dead key characters are not yet handled (especially those on
-  the numrow).
+- Some exotic characters may be missing, please report bugs.
 - Layer taps are not supported at this point.
 - Home row mods are not supported at this point.

--- a/drivers/ergol-kanata/defalias_azerty_pc.kbd
+++ b/drivers/ergol-kanata/defalias_azerty_pc.kbd
@@ -76,7 +76,7 @@
   s7 7
   s8 8
   s9 9
-  nbs spc ;; no narrow no-break space in Azerty
+  nbs (unicode  ) ;; narrow non-break space
 
   dk1 XX
   dk2 XX

--- a/drivers/ergol-kanata/defalias_azerty_pc.kbd
+++ b/drivers/ergol-kanata/defalias_azerty_pc.kbd
@@ -1,0 +1,88 @@
+;; Azerty Windows/Linux aliases
+;; Works with AZERTY-fr. Needs a couple tweaks for the Belgian and Mac variants.
+
+;; Navigation layer
+(defalias
+
+  all C-q
+  sav C-s
+  cls C-z
+  ndo C-w
+  cut C-x
+  cpy C-c
+  pst C-v
+
+  0 S-0
+  1 S-1
+  2 S-2
+  3 S-3
+  4 S-4
+  5 S-5
+  6 S-6
+  7 S-7
+  8 S-8
+  9 S-9
+  , m
+  . S-,
+)
+
+;; Symbols layer
+(defalias
+
+  ^  (macro [ spc)
+  <  <
+  >  S-<
+  $  ]
+  %  S-'
+  @  AG-0
+  &  1
+  *  \
+  '  4
+  `  (macro AG-7 spc)
+
+  {  AG-4
+  pl 5
+  pr -
+  }  AG-=
+  =  =
+  \  AG-8
+  +  S-=
+  -  6
+  /  S-.
+  '' 3
+
+  ~  (macro AG-2 spc)
+  [  AG-5
+  ]  AG--
+  _  8
+  #  AG-3
+  |  AG-6
+  !  /
+  ;  ,
+  :  .
+  ?  S-m
+)
+
+;; NumRow layer
+(defalias
+
+  s0 0
+  s1 1
+  s2 2
+  s3 3
+  s4 4
+  s5 5
+  s6 6
+  s7 7
+  s8 8
+  s9 9
+  nbs spc ;; no narrow no-break space in Azerty
+
+  dk1 XX
+  dk2 XX
+  dk3 XX
+  dk4 XX
+  dk5 XX
+)
+
+;; vim: set ft=lisp

--- a/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
+++ b/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
@@ -1,0 +1,150 @@
+;; Emulation of Ergo-L over an Azerty-FR keymap -- main layers
+
+(deftemplate dk-sft (base-action shift-action)
+  (fork (unicode $base-action) (unicode $shift-action) (lsft rsft))
+)
+
+(defalias
+  sym (layer-while-held symbols)
+
+  ;; Shift mods
+  sft0 (multi lsft (layer-while-held baseSft))
+  sft1 (multi lsft (layer-while-held dk1))
+  sft2 (multi lsft (layer-while-held dk2))
+  sft3 (multi lsft (layer-while-held dk3))
+
+  ;; dead key (becomes exclamation mark when shifte)
+  dk (fork
+    (tap-dance 5000 (
+      (one-shot-press 5000 (layer-while-held dk1))
+      (one-shot-press 5000 (layer-while-held dk2))
+      (one-shot-press 5000 (layer-while-held dk3))
+    ))
+    (unicode !)
+    (lsft rsft)
+  )
+)
+
+;; Base layer
+(defalias
+  spce (fork spc (unicode  ) (lsft rsft)) ;; space / narrow no-break space
+
+  dash (t! dk-sft - ?)
+  dot (t! dk-sft . :)
+  com (t! dk-sft , ;)
+
+  b0 (t! dk-sft 0 @)
+  b1 (t! dk-sft 1 €)
+  b2 (t! dk-sft 2 «)
+  b3 (t! dk-sft 3 »)
+  b4 (t! dk-sft 4 $)
+  b5 (t! dk-sft 5 %)
+  b6 (t! dk-sft 6 ^)
+  b7 (t! dk-sft 7 &)
+  b8 (t! dk-sft 8 *)
+  b9 (t! dk-sft 9 #)
+)
+
+;; sft0
+(defalias
+  ?sft m
+  !sft (unshift /)
+  ;sft (unshift ,)
+  :sft (unshift .)
+)
+
+;; Dead key layer 1
+(defalias
+  smark (unicode ’)
+
+  Â (t! dk-sft â Â)
+  Ç (t! dk-sft ç Ç)
+  Œ (t! dk-sft œ Œ)
+  Ô (t! dk-sft ô Ô)
+  µ (fork (unicode µ) XX (lsft rsft))
+  _dk (unshift 8)
+  Û (t! dk-sft û Û)
+
+  À (t! dk-sft à À)
+  É (t! dk-sft é É)
+  È (t! dk-sft è È)
+  Ê (t! dk-sft ê Ê)
+  Ñ (t! dk-sft ñ Ñ)
+  lpar (fork 5 XX (lsft rsft))
+  rpar (fork - XX (lsft rsft))
+  Î (t! dk-sft î Î)
+  Ï (t! dk-sft ï Ï)
+  Ù (t! dk-sft ù Ù)
+
+  Æ (t! dk-sft æ Æ)
+  ẞ (t! dk-sft ß ẞ)
+  ¿ (t! dk-sft ‑ ¿)
+  – (fork (unicode –) XX (lsft rsft))
+  — (fork (unicode —) XX (lsft rsft))
+  … (fork (unicode …) XX (lsft rsft))
+  • (t! dk-sft · •)
+)
+
+;; Dead key layer 2
+(defalias
+  mark 3
+
+  Ö (t! dk-sft ö Ö)
+  Ẅ (t! dk-sft ẅ Ẅ)
+  Ÿ (t! dk-sft ÿ Ÿ)
+
+  Ä (t! dk-sft ä Ä)
+  Ë (t! dk-sft ë Ë)
+  ẗ (fork (unicode ẗ) XX (lsft rsft))
+  Ü (t! dk-sft ü Ü)
+
+  Ẍ (t! dk-sft ẍ Ẍ)
+  Ḧ (t! dk-sft ḧ Ḧ)
+)
+
+;; Dead key layer 3
+(defalias
+  diaeresis (unicode ¨)
+)
+
+(deflayer base
+  @b1   @b2   @b3   @b4   @b5   _        @b6   @b7   @b8   @b9   @b0
+  a     c     o     p     z              j     ;     d     @dk   y
+  q     s     e     n     f              l     r     t     i     u
+  w     x     @dash v     b     <        @dot  h     g     @com  k
+  @sft0       _                 @spce             @sym        @sft0
+)
+
+(deflayer baseSft
+  _     _     _     _     _     _        _     _     _     _     _
+  a     c     o     p     z              j     ;     d     @!sft y
+  q     s     e     n     f              l     r     t     i     u
+  w     x     @?sft v     b     _        @:sft h     g     @;sft k
+  _           _                 _                    _           _
+)
+
+(deflayer dk1
+  _     _     _     _     _     _        _     _     _     _     _
+  @Â    @Ç    @Œ   @Ô     _              _     @µ    @_dk  @dk   @Û
+  @À    @É    @È   @Ê     @Ñ             @lpar @rpar @Î    @Ï    @Ù
+  @Æ    @ẞ    @¿   @–     @—    _        @…    XX    XX    @•    XX
+  @sft1       _                 @smark               _        @sft1
+)
+
+(deflayer dk2
+  _     _     _     _     _     _        _     _     _     _     _
+  a     c     @Ö    p     @Ẅ             j     ;     d     @dk   @Ÿ
+  @Ä    s     @Ë    n     f              l     r     @ẗ    @Ï    @Ü
+  w     @Ẍ    @-    v     b     _        @.    @Ḧ    g     m     k
+  @sft2       _                 @mark                _        @sft2
+)
+
+(deflayer dk3
+  _     _     _     _     _     _        _     _     _     _     _
+  a     c     o     p     z              j     ;     d     @dk   y
+  q     s     e     n     f              l     r     t     i     u
+  w     x     @-    v     b     _        @.    h     g     m     k
+  @sft3       _                 @diaeresis           _        @sft3
+)
+
+;; vim: set ft=lisp

--- a/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
+++ b/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
@@ -57,6 +57,15 @@
 (defalias
   smark (unicode ’)
 
+  „ (t! dk-sft „ ‚)
+  “ (t! dk-sft “ ‘)
+  ” (t! dk-sft ” ’)
+  ¢ (unicode ¢)
+  ‰ (unicode ‰)
+  § (unicode §)
+  ¶ (unicode ¶)
+  ° (unicode °)
+
   Â (t! dk-sft â Â)
   Ç (t! dk-sft ç Ç)
   Œ (t! dk-sft œ Œ)
@@ -124,7 +133,7 @@
 )
 
 (deflayer dk1
-  _     _     _     _     _     _        _     _     _     _     _
+  @„    @“    @”   @¢     @‰    _        _     _     @§    @¶    @°
   @Â    @Ç    @Œ   @Ô     _              _     @µ    @_dk  @dk   @Û
   @À    @É    @È   @Ê     @Ñ             @lpar @rpar @Î    @Ï    @Ù
   @Æ    @ẞ    @¿   @–     @—    _        @…    XX    XX    @•    XX

--- a/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
+++ b/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
@@ -29,11 +29,8 @@
 (defalias
   spce (fork spc (unicode  ) (lsft rsft)) ;; space / narrow no-break space
 
-  dash (t! dk-sft - ?)
-  dot (t! dk-sft . :)
-  com (t! dk-sft , ;)
-
-  b0 (t! dk-sft 0 @)
+  ;; numbers row
+  acc (t! dk-sft ` ~)
   b1 (t! dk-sft 1 €)
   b2 (t! dk-sft 2 «)
   b3 (t! dk-sft 3 »)
@@ -43,6 +40,20 @@
   b7 (t! dk-sft 7 &)
   b8 (t! dk-sft 8 *)
   b9 (t! dk-sft 9 #)
+  b0 (t! dk-sft 0 @)
+  slsh (t! dk-sft / _)
+  eq (t! dk-sft = +)
+
+  ;; right-hand "extras"
+  brk1 (t! dk-sft [ {)
+  brk2 (t! dk-sft ] })
+  qte (fork 4 (unshift 3) (lsft rsft))  ;; '  "
+  bksl (t! dk-sft \ |)
+
+  ;; lower row
+  dash (t! dk-sft - ?)
+  dot (t! dk-sft . :)
+  com (t! dk-sft , ;)
 )
 
 ;; sft0
@@ -117,9 +128,9 @@
 )
 
 (deflayer base
-  _    @b1   @b2   @b3   @b4   @b5   _   @b6   @b7   @b8   @b9   @b0  _    _
-       a     c     o     p     z         j     ;     d     @dk   y    _    _
-       q     s     e     n     f         l     r     t     i     u    _    _
+  @acc @b1   @b2   @b3   @b4   @b5   _   @b6   @b7   @b8   @b9   @b0  @slsh @eq
+       a     c     o     p     z         j     ;     d     @dk   y    @brk1 @brk2
+       q     s     e     n     f         l     r     t     i     u    @qte  @bksl
        w     x     @dash v     b     <   @dot  h     g     @com  k
   @sft0            _               @spce       @sym              @sft0
 )

--- a/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
+++ b/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
@@ -117,43 +117,43 @@
 )
 
 (deflayer base
-  @b1   @b2   @b3   @b4   @b5   _        @b6   @b7   @b8   @b9   @b0
-  a     c     o     p     z              j     ;     d     @dk   y
-  q     s     e     n     f              l     r     t     i     u
-  w     x     @dash v     b     <        @dot  h     g     @com  k
-  @sft0       _                 @spce             @sym        @sft0
+  _    @b1   @b2   @b3   @b4   @b5   _   @b6   @b7   @b8   @b9   @b0  _    _
+       a     c     o     p     z         j     ;     d     @dk   y    _    _
+       q     s     e     n     f         l     r     t     i     u    _    _
+       w     x     @dash v     b     <   @dot  h     g     @com  k
+  @sft0            _               @spce       @sym              @sft0
 )
 
 (deflayer baseSft
-  _     _     _     _     _     _        _     _     _     _     _
-  a     c     o     p     z              j     ;     d     @!sft y
-  q     s     e     n     f              l     r     t     i     u
-  w     x     @?sft v     b     _        @:sft h     g     @;sft k
-  _           _                 _                    _           _
+  _    _     _     _     _     _    _    _     _     _     _     _    _    _
+       a     c     o     p     z         j     ;     d     @!sft y    _    _
+       q     s     e     n     f         l     r     t     i     u    _    _
+       w     x     @?sft v     b    _    @:sft h     g     @;sft k
+  _                _                _          _                 _
 )
 
 (deflayer dk1
-  @„    @“    @”   @¢     @‰    _        _     _     @§    @¶    @°
-  @Â    @Ç    @Œ   @Ô     _              _     @µ    @_dk  @dk   @Û
-  @À    @É    @È   @Ê     @Ñ             @lpar @rpar @Î    @Ï    @Ù
-  @Æ    @ẞ    @¿   @–     @—    _        @…    XX    XX    @•    XX
-  @sft1       _                 @smark               _        @sft1
+  _    @„    @“    @”   @¢     @‰   _    _     _     @§    @¶    @°   _    _
+       @Â    @Ç    @Œ   @Ô     _         _     @µ    @_dk  @dk   @Û   _    _
+       @À    @É    @È   @Ê     @Ñ        @lpar @rpar @Î    @Ï    @Ù   _    _
+       @Æ    @ẞ    @¿   @–     @—   _    @…    XX    XX    @•    XX
+  @sft1            _              @smark       _                 @sft1
 )
 
 (deflayer dk2
-  _     _     _     _     _     _        _     _     _     _     _
-  a     c     @Ö    p     @Ẅ             j     ;     d     @dk   @Ÿ
-  @Ä    s     @Ë    n     f              l     r     @ẗ    @Ï    @Ü
-  w     @Ẍ    @-    v     b     _        @.    @Ḧ    g     m     k
-  @sft2       _                 @mark                _        @sft2
+  _    _     _     _     _     _    _    _     _     _     _     _    _    _
+       a     c     @Ö    p     @Ẅ        j     ;     d     @dk   @Ÿ   _    _
+       @Ä    s     @Ë    n     f         l     r     @ẗ    @Ï    @Ü   _    _
+       w     @Ẍ    @-    v     b    _    @.    @Ḧ    g     m     k
+  @sft2            _              @mark        _                 @sft2
 )
 
 (deflayer dk3
-  _     _     _     _     _     _        _     _     _     _     _
-  a     c     o     p     z              j     ;     d     @dk   y
-  q     s     e     n     f              l     r     t     i     u
-  w     x     @-    v     b     _        @.    h     g     m     k
-  @sft3       _                 @diaeresis           _        @sft3
+  _    _     _     _     _     _    _    _     _     _     _     _    _    _
+       a     c     o     p     z         j     ;     d     @dk   y    _    _
+       q     s     e     n     f         l     r     t     i     u    _    _
+       w     x     @-    v     b    _    @.    h     g     m     k
+  @sft3            _           @diaeresis      _                 @sft3
 )
 
 ;; vim: set ft=lisp

--- a/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
+++ b/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
@@ -1,14 +1,26 @@
-;; Symbol layer: Lafayette/Ergo‑L AltGr programmation layer for the masses!
+;; Symbol layers
+
+(defalias
+  ;; subscript digits
+  ₁ (unicode ₁)
+  ₂ (unicode ₂)
+  ₃ (unicode ₃)
+  ₄ (unicode ₄)
+  ₅ (unicode ₅)
+  ₆ (unicode ₆)
+  ₇ (unicode ₇)
+  ₈ (unicode ₈)
+  ₉ (unicode ₉)
+  ₀ (unicode ₀)
+)
 
 (deflayer symbols
-  _ AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0 _ _
+  _ @₁   @₂   @₃   @₄   @₅   XX   @₆   @₇   @₈   @₉   @₀   _ _
     @^   @<   @>   @$   @%        @@   @&   @*   @'   @`   _ _
     @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''  _ _
     @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
   _           _              spc       _              _
 )
 
-;; Note: this requires kanata 0.5+ to work properly.
-;; kanata 0.4 does not release Shift soon enough for this layer to work.
 
 ;; vim: set ft=lisp

--- a/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
+++ b/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
@@ -1,6 +1,9 @@
 ;; Symbol layers
 
+;; main symbols layer aliases
 (defalias
+  sym2 (layer-while-held symbolsSft)
+
   ;; subscript digits
   ₁ (unicode ₁)
   ₂ (unicode ₂)
@@ -14,13 +17,64 @@
   ₀ (unicode ₀)
 )
 
-(deflayer symbols
-  _ @₁   @₂   @₃   @₄   @₅   XX   @₆   @₇   @₈   @₉   @₀   _ _
-    @^   @<   @>   @$   @%        @@   @&   @*   @'   @`   _ _
-    @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''  _ _
-    @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
-  _           _              spc       _              _
+;; shifted symbols layer aliases
+(defalias
+  ;; superscript digits
+  ¹ (unicode ¹)
+  ² (unicode ²)
+  ³ (unicode ³)
+  ⁴ (unicode ⁴)
+  ⁵ (unicode ⁵)
+  ⁶ (unicode ⁶)
+  ⁷ (unicode ⁷)
+  ⁸ (unicode ⁸)
+  ⁹ (unicode ⁹)
+  ⁰ (unicode ⁰)
+
+  ;; TODO: dead ^
+  ≤ (unicode ≤)
+  ≥ (unicode ≥)
+  ;; TODO: dead ¤
+  ;; TODO: dead ˚
+  × (unicode ×)
+  ;; TODO: dead '
+  ;; TODO: dead `
+
+  ;; TODO: dead ˇ
+  ;; TODO: dead ˙
+  ≠ (unicode ≠)
+  ;; TODO: dead /
+  ± (unicode ±)
+  ;; TODO: dead ˉ
+  ÷ (unicode ÷)
+  ;; TODO: dead ˝
+
+  ;; TODO: dead ~
+  ;; TODO: dead ,
+  ;; TODO: dead ˛
+  ¦ (unicode ¦)
+  ¬ (unicode ¬)
+  ;; TODO: dead ¸
+  ;; TODO: dead ˘
 )
 
+(deflayer symbols
+  XX   @₁   @₂   @₃   @₄   @₅   XX   @₆   @₇   @₈   @₉   @₀   XX XX
+       @^   @<   @>   @$   @%        @@   @&   @*   @'   @`   XX XX
+       @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''  XX XX
+       @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
+  @sym2          _             spc        _              @sym2
+)
+
+;; TODO: on letter rows below, the _ correspond to unimplemented dead
+;;       keys (see above to dos). XX are where keys are actually not
+;;       supposed to have any effect.
+(deflayer symbolsSft
+  XX   @¹   @²   @³   @⁴   @⁵   XX   @⁶   @⁷   @⁸   @⁹   @⁰   XX XX
+       _    @≤   @≥   _    @‰        _    XX   @×   _    _    XX XX
+       _    XX   XX   _    @≠        _    @±   _    @÷   _    XX XX
+       _    _    _    @–   XX   XX   @¦   @¬   _    @:   _
+  _              _             spc        _              _
+)
 
 ;; vim: set ft=lisp

--- a/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
+++ b/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
@@ -1,11 +1,11 @@
 ;; Symbol layer: Lafayette/Ergo‑L AltGr programmation layer for the masses!
 
 (deflayer symbols
-  AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0
-  @^   @<   @>   @$   @%        @@   @&   @*   @'   @`
-  @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''
-  @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
-  _         _             spc             _         _
+  _ AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0 _ _
+    @^   @<   @>   @$   @%        @@   @&   @*   @'   @`   _ _
+    @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''  _ _
+    @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
+  _           _              spc       _              _
 )
 
 ;; Note: this requires kanata 0.5+ to work properly.

--- a/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
+++ b/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
@@ -1,0 +1,14 @@
+;; Symbol layer: Lafayette/Ergo‑L AltGr programmation layer for the masses!
+
+(deflayer symbols
+  AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0
+  @^   @<   @>   @$   @%        @@   @&   @*   @'   @`
+  @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''
+  @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
+  _         _             spc             _         _
+)
+
+;; Note: this requires kanata 0.5+ to work properly.
+;; kanata 0.4 does not release Shift soon enough for this layer to work.
+
+;; vim: set ft=lisp

--- a/drivers/ergol-kanata/defsrc_pc.kbd
+++ b/drivers/ergol-kanata/defsrc_pc.kbd
@@ -1,11 +1,11 @@
 ;; `defsrc` defines the keys that will be intercepted by kanata.
 
 (defsrc
-  1    2    3    4    5  bspc   6    7    8    9    0
-  q    w    e    r    t         y    u    i    o    p
-  a    s    d    f    g         h    j    k    l    ;
-  z    x    c    v    b    <    n    m    ,    .    /
-  lsft      lalt          spc           ralt     rsft
+  `    1    2    3    4    5  bspc   6    7    8    9    0    -    =
+       q    w    e    r    t         y    u    i    o    p    [    ]
+       a    s    d    f    g         h    j    k    l    ;    '    \
+       z    x    c    v    b    <    n    m    ,    .    /
+  lsft           lalt          spc        ralt           rsft
 )
 
 ;; vim: set ft=lisp

--- a/drivers/ergol-kanata/defsrc_pc.kbd
+++ b/drivers/ergol-kanata/defsrc_pc.kbd
@@ -1,0 +1,11 @@
+;; `defsrc` defines the keys that will be intercepted by kanata.
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  z    x    c    v    b    <    n    m    ,    .    /
+  lsft      lalt          spc           ralt     rsft
+)
+
+;; vim: set ft=lisp

--- a/drivers/ergol-kanata/defsrc_pc_anglemod.kbd
+++ b/drivers/ergol-kanata/defsrc_pc_anglemod.kbd
@@ -1,11 +1,11 @@
 ;; angle-mod: the ISO key (a.k.a. LSGT or 102 key) becomes Z
 
 (defsrc
-  1    2    3    4    5  bspc   6    7    8    9    0
-  q    w    e    r    t         y    u    i    o    p
-  a    s    d    f    g         h    j    k    l    ;
-  <    z    x    c    v    b    n    m    ,    .    /
-  lsft      lalt          spc           ralt     rsft
+  `    1    2    3    4    5  bspc   6    7    8    9    0    -    =
+       q    w    e    r    t         y    u    i    o    p    [    ]
+       a    s    d    f    g         h    j    k    l    ;    '    \
+       <    z    x    c    v    b    n    m    ,    .    /
+  lsft           lalt          spc        ralt           rsft
 )
 
 ;; vim: set ft=lisp

--- a/drivers/ergol-kanata/defsrc_pc_anglemod.kbd
+++ b/drivers/ergol-kanata/defsrc_pc_anglemod.kbd
@@ -1,0 +1,11 @@
+;; angle-mod: the ISO key (a.k.a. LSGT or 102 key) becomes Z
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  <    z    x    c    v    b    n    m    ,    .    /
+  lsft      lalt          spc           ralt     rsft
+)
+
+;; vim: set ft=lisp

--- a/drivers/ergol-kanata/kanata.kbd
+++ b/drivers/ergol-kanata/kanata.kbd
@@ -1,0 +1,47 @@
+;;==========================================================================;;
+;;                                                                          ;;
+;;  Ergo-L "portable" driver, emulated with Kanata over your regular keymap ;;
+;;                                                                          ;;
+;;==========================================================================;;
+
+
+;;-----------------------------------------------------------------------------
+;; Choose here if you want to add an angle mod: ZXCVB are shifted to the left.
+;; See https://colemakmods.github.io/ergonomic-mods/angle.html for more details.
+
+(include defsrc_pc.kbd)  ;; PC, standard finger assignment
+;;(include defsrc_pc_anglemod.kbd)  ;; PC, ZXCVB are shifted to the left
+
+
+;;-----------------------------------------------------------------------------
+;; Base keymap
+
+(include deflayer_base_over_azerty.kbd)  ;; Azerty-FR
+
+
+;;-----------------------------------------------------------------------------
+;; `Symbols` layer
+;; You need this, don’t disable it.
+
+(include deflayer_symbols_lafayette.kbd)
+
+
+;;-----------------------------------------------------------------------------
+;; Aliases for `Symbols` and `Navigation` layers
+;; Depends on PC/Mac and keyboard layout
+
+(include defalias_azerty_pc.kbd)  ;; Azerty-FR, PC
+
+
+;;-----------------------------------------------------------------------------
+;; Extra configuration
+;; You should not modify this, only if you need to.
+
+(defcfg
+  ;; Enabled makes kanata process keys that are not defined in defsrc
+  ;; Fixes altgr for Windows (see Arsenik issue #22)
+  process-unmapped-keys yes
+  windows-altgr cancel-lctl-press
+)
+
+;; vim: set ft=lisp


### PR DESCRIPTION
This is a preliminary implementation of Ergo-L in Kanata, based on Azerty-FR PC.

The code comes mainly from <https://github.com/AxelDvch/setup>, thank you Axel!

For now, only the basic keymap is (mostly) handled (no layer taps nor home row mods).

Co-authored-by: AxelDvch