### PR TITLE
fix: complete noop symbols layer with AG-<

### DIFF
--- a/kanata/deflayer_symbols_noop.kbd
+++ b/kanata/deflayer_symbols_noop.kbd
@@ -7,7 +7,7 @@
   AG-1 AG-2 AG-3 AG-4 AG-5  XX  AG-6 AG-7 AG-8 AG-9 AG-0
   AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
   AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
-  AG-z AG-x AG-c AG-v AG-b  XX  AG-n AG-m AG-, AG-. AG-/
+  AG-z AG-x AG-c AG-v AG-b AG-< AG-n AG-m AG-, AG-. AG-/
             _             AG-spc          _
 )
 

--- a/kanata/deflayer_symbols_noop_num.kbd
+++ b/kanata/deflayer_symbols_noop_num.kbd
@@ -8,7 +8,7 @@
   AG-1 AG-2 AG-3 AG-4 AG-5  XX  AG-6 AG-7 AG-8 AG-9 AG-0
   AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
   AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
-  AG-z AG-x AG-c AG-v AG-b  XX  AG-n AG-m AG-, AG-. AG-/
+  AG-z AG-x AG-c AG-v AG-b AG-< AG-n AG-m AG-, AG-. AG-/
             @num          AG-spc          _
 )
 


### PR DESCRIPTION
Useless with Ergo-L, but may be useful with bépo to output a `/` (if not using the lafayette symbols layer), and in my case, with my Ergo-L anglemod xkb layout to output a `~`.