### PR TITLE
fix(kanata): properly define the timing variables.

### DIFF
--- a/kanata/deflayer/base_lt.kbd
+++ b/kanata/deflayer/base_lt.kbd
@@ -8,15 +8,7 @@
             @alt          @nav            @sym
 )
 
-;; Timing variables for tap-hold effects.
-(defvar
-  ;; The key must be pressed twice in 200ms to enable repetitions.
-  tap_timeout 200
-  ;; The key must be held 200ms to become a layer shift.
-  hold_timeout 200
-  ;; Slightly higher value for tapying keys, to prevent unexpected hold effect.
-  long_hold_timeout 300
-)
+;; Timing variables are defined in `kanata.kbd` file.
 
 (defalias
   ;; Main mod-tap: Nav layer when held, Space when tapped.

--- a/kanata/deflayer/base_lt_hrm.kbd
+++ b/kanata/deflayer/base_lt_hrm.kbd
@@ -8,15 +8,7 @@
             @sft          @nav            @sym
 )
 
-;; Timing variables for tap-hold effects.
-(defvar
-  ;; The key must be pressed twice in 200ms to enable repetitions.
-  tap_timeout 200
-  ;; The key must be held 300ms to become a layer shift.
-  long_hold_timeout 300
-  ;; Slightly higher value for tapying keys, to prevent unexpected hold effect.
-  long_hold_timeout 300
-)
+;; Timing variables are defined in `kanata.kbd` file.
 
 (defalias
   ;; Main mod-tap: Nav layer when held, Space when tapped.

--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -11,6 +11,15 @@
 
 ;; Live-reload the configuration with Space+Backspace (requires layer-taps).
 
+;; Timing variables for tap-hold effects.
+(defvar
+  ;; The key must be pressed twice in 200ms to enable repetitions.
+  tap_timeout 200
+  ;; The key must be held 200ms to become a layer shift.
+  hold_timeout 200
+  ;; Slightly higher value for typing keys, to prevent unexpected hold effect.
+  long_hold_timeout 300
+)
 
 ;;-----------------------------------------------------------------------------
 ;; Original key arrangement on your keyboard: Mac or PC.


### PR DESCRIPTION
This is a follow up to #40 to fix the bugs found in #43 (that were pretty obvious but I didn’t check, my bad). To prevent having discrepancies in timing between the different files, I defined the variables in the main `kanata.kbd` file.