### PR TITLE
Vimnav improvements

### DIFF
--- a/img/vim_navigation.svg
+++ b/img/vim_navigation.svg
@@ -72,6 +72,7 @@
       <g transform="translate(330)">
         <rect width="52" height="52" rx="5" ry="5"/>
         <text x="12.8" y="20.6" class="level2">T</text>
+        <text x="38.0" y="20.6" class="layerNav">↦</text>
       </g>
     </g>
     <g class="right">
@@ -127,6 +128,7 @@
       <g transform="translate(330)">
         <rect width="52" height="52" rx="5" ry="5"/>
         <text x="12.8" y="20.6" class="level2">G</text>
+        <text x="38.0" y="20.6" class="layerNav">⎌</text>
       </g>
     </g>
     <g class="right">
@@ -194,6 +196,7 @@
         <rect width="52" height="52" rx="5" ry="5"/>
         <g>
           <text x="12.8" y="20.6" class="level2">B</text>
+        <text x="38.0" y="20.6" class="layerNav">↤</text>
         </g>
       </g>
     </g>
@@ -228,6 +231,7 @@
         <rect width="52" height="52" rx="5" ry="5"/>
         <text x="12.8" y="43.4" class="level1">/</text>
         <text x="12.8" y="20.6" class="level2">?</text>
+        <text x="38.0" y="20.6" class="layerNav shortcut">redo</text>
       </g>
     </g>
   </g>

--- a/kanata/defalias/azerty_pc.kbd
+++ b/kanata/defalias/azerty_pc.kbd
@@ -11,6 +11,8 @@
   cut C-x
   cpy C-c
   pst C-v
+  nwd C-rght
+  pwd C-lft
 
   0 S-0
   1 S-1

--- a/kanata/defalias/azerty_pc.kbd
+++ b/kanata/defalias/azerty_pc.kbd
@@ -13,6 +13,7 @@
   pst C-v
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 S-0
   1 S-1

--- a/kanata/defalias/azerty_pc.kbd
+++ b/kanata/defalias/azerty_pc.kbd
@@ -8,6 +8,7 @@
   sav C-s
   cls C-z
   ndo C-w
+  rdo C-y
   cut C-x
   cpy C-c
   pst C-v

--- a/kanata/defalias/bepo_pc.kbd
+++ b/kanata/defalias/bepo_pc.kbd
@@ -10,6 +10,8 @@
   cut C-c
   cpy C-h
   pst C-u
+  nwd C-rght
+  pwd C-lft
 
   0 S-0
   1 S-1

--- a/kanata/defalias/bepo_pc.kbd
+++ b/kanata/defalias/bepo_pc.kbd
@@ -12,6 +12,7 @@
   pst C-u
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 S-0
   1 S-1

--- a/kanata/defalias/bepo_pc.kbd
+++ b/kanata/defalias/bepo_pc.kbd
@@ -7,6 +7,7 @@
   sav C-k
   cls C-]
   ndo C-[
+  rdo C-x
   cut C-c
   cpy C-h
   pst C-u

--- a/kanata/defalias/ergol_pc.kbd
+++ b/kanata/defalias/ergol_pc.kbd
@@ -12,6 +12,7 @@
   pst C-v
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 0
   1 1

--- a/kanata/defalias/ergol_pc.kbd
+++ b/kanata/defalias/ergol_pc.kbd
@@ -10,6 +10,8 @@
   cut C-x
   cpy C-w
   pst C-v
+  nwd C-rght
+  pwd C-lft
 
   0 0
   1 1

--- a/kanata/defalias/ergol_pc.kbd
+++ b/kanata/defalias/ergol_pc.kbd
@@ -7,6 +7,7 @@
   sav C-s
   cls C-t
   ndo C-z
+  rdo C-p
   cut C-x
   cpy C-w
   pst C-v

--- a/kanata/defalias/optimot_pc.kbd
+++ b/kanata/defalias/optimot_pc.kbd
@@ -7,6 +7,7 @@
   sav C-k
   cls C-v
   ndo C-]
+  rdo C-z
   cut C-[
   cpy C-m
   pst C-/

--- a/kanata/defalias/optimot_pc.kbd
+++ b/kanata/defalias/optimot_pc.kbd
@@ -12,6 +12,7 @@
   pst C-/
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 S-0
   1 S-1

--- a/kanata/defalias/optimot_pc.kbd
+++ b/kanata/defalias/optimot_pc.kbd
@@ -10,6 +10,8 @@
   cut C-[
   cpy C-m
   pst C-/
+  nwd C-rght
+  pwd C-lft
 
   0 S-0
   1 S-1

--- a/kanata/defalias/qwerty-lafayette_pc.kbd
+++ b/kanata/defalias/qwerty-lafayette_pc.kbd
@@ -12,6 +12,7 @@
   pst C-v
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 0
   1 1

--- a/kanata/defalias/qwerty-lafayette_pc.kbd
+++ b/kanata/defalias/qwerty-lafayette_pc.kbd
@@ -10,6 +10,8 @@
   cut C-x
   cpy C-c
   pst C-v
+  nwd C-rght
+  pwd C-lft
 
   0 0
   1 1

--- a/kanata/defalias/qwerty-lafayette_pc.kbd
+++ b/kanata/defalias/qwerty-lafayette_pc.kbd
@@ -7,6 +7,7 @@
   sav C-s
   cls C-w
   ndo C-z
+  rdo C-y
   cut C-x
   cpy C-c
   pst C-v

--- a/kanata/defalias/qwerty_mac.kbd
+++ b/kanata/defalias/qwerty_mac.kbd
@@ -10,6 +10,8 @@
   cut M-x
   cpy M-c
   pst M-v
+  nwd A-rght
+  pwd A-lft
 
   0 0
   1 1

--- a/kanata/defalias/qwerty_mac.kbd
+++ b/kanata/defalias/qwerty_mac.kbd
@@ -7,6 +7,7 @@
   sav M-s
   cls M-w
   ndo M-z
+  rdo M-y
   cut M-x
   cpy M-c
   pst M-v

--- a/kanata/defalias/qwerty_mac.kbd
+++ b/kanata/defalias/qwerty_mac.kbd
@@ -12,6 +12,7 @@
   pst M-v
   nwd A-rght
   pwd A-lft
+  swp M-tab
 
   0 0
   1 1

--- a/kanata/defalias/qwerty_pc.kbd
+++ b/kanata/defalias/qwerty_pc.kbd
@@ -13,6 +13,7 @@
   pst C-v
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 0
   1 1

--- a/kanata/defalias/qwerty_pc.kbd
+++ b/kanata/defalias/qwerty_pc.kbd
@@ -8,6 +8,7 @@
   sav C-s
   cls C-w
   ndo C-z
+  rdo C-y
   cut C-x
   cpy C-c
   pst C-v

--- a/kanata/defalias/qwerty_pc.kbd
+++ b/kanata/defalias/qwerty_pc.kbd
@@ -11,6 +11,8 @@
   cut C-x
   cpy C-c
   pst C-v
+  nwd C-rght
+  pwd C-lft
 
   0 0
   1 1

--- a/kanata/defalias/qwertz_pc.kbd
+++ b/kanata/defalias/qwertz_pc.kbd
@@ -13,6 +13,7 @@
   pst C-v
   nwd C-rght
   pwd C-lft
+  swp A-tab
 
   0 0
   1 1

--- a/kanata/defalias/qwertz_pc.kbd
+++ b/kanata/defalias/qwertz_pc.kbd
@@ -8,6 +8,7 @@
   sav C-s
   cls C-w
   ndo C-y
+  rdo C-z
   cut C-x
   cpy C-c
   pst C-v

--- a/kanata/defalias/qwertz_pc.kbd
+++ b/kanata/defalias/qwertz_pc.kbd
@@ -11,6 +11,8 @@
   cut C-x
   cpy C-c
   pst C-v
+  nwd C-rght
+  pwd C-lft
 
   0 0
   1 1

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -1,5 +1,5 @@
 ;; Vim-Navigation layer:
-;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll
+;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll, Cmd/Ctrl-Y
 ;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, Alt-Tab, prev/next, Ctrl/Alt-Left/Right
 ;;  - top: Super-num (i3/sway) or Alt-num (browser), zoom in/out
 
@@ -10,7 +10,7 @@
   M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
   @pad @cls bck  fwd  @nwd      home pgdn pgup end  @run
   @all @sav S-tab tab @swp      lft  down up   rght @fun
-  @ndo @cut @cpy @pst @pwd  _   @mwl @mwd @mwu @mwr XX
+  @ndo @cut @cpy @pst @pwd  _   @mwl @mwd @mwu @mwr @rdo
             del             _             esc
 )
 

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -1,6 +1,6 @@
 ;; Vim-Navigation layer:
 ;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll
-;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, prev/next
+;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, prev/next, Ctrl/Alt-Left/Right
 ;;  - top: Super-num (i3/sway) or Alt-num (browser), zoom in/out
 
 ;; The `lrld` action stands for "live reload". This will re-parse everything
@@ -8,9 +8,9 @@
 
 (deflayer navigation
   M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
-  @pad @cls bck  fwd  XX        home pgdn pgup end  @run
+  @pad @cls bck  fwd  @nwd      home pgdn pgup end  @run
   @all @sav S-tab tab XX        lft  down up   rght @fun
-  @ndo @cut @cpy @pst XX    _   @mwl @mwd @mwu @mwr XX
+  @ndo @cut @cpy @pst @pwd  _   @mwl @mwd @mwu @mwr XX
             del             _             esc
 )
 

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -1,6 +1,6 @@
 ;; Vim-Navigation layer:
 ;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll
-;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, prev/next, Ctrl/Alt-Left/Right
+;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, Alt-Tab, prev/next, Ctrl/Alt-Left/Right
 ;;  - top: Super-num (i3/sway) or Alt-num (browser), zoom in/out
 
 ;; The `lrld` action stands for "live reload". This will re-parse everything
@@ -9,7 +9,7 @@
 (deflayer navigation
   M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
   @pad @cls bck  fwd  @nwd      home pgdn pgup end  @run
-  @all @sav S-tab tab XX        lft  down up   rght @fun
+  @all @sav S-tab tab @swp      lft  down up   rght @fun
   @ndo @cut @cpy @pst @pwd  _   @mwl @mwd @mwu @mwr XX
             del             _             esc
 )


### PR DESCRIPTION
Here’s my humble attempt at filling the gaps in the vim navigation layer 🙂 

### Next/previous word – *nwd/pwd*

- `C-rght` → `[T]`
- `C-lft` → `[B]`

Word-by-word navigation in every text area! This one is definitely biased towards Ergo‑L as it maps perfectly with its `w` and `b`, so the position is the same as in vim. 

### Alt-tab – *swp*

- `A-tab` → `[G]`

Quickly swap between two applications! The mapping is located right next to `S-tab` and `tab`.

### ~~Find – *fnd*~~

- ~~`C-f` → `[G]`~~

~~Still quite biased towards Ergo‑L, but in this case we’re not so far from Qwerty’s `f`.~~

### Redo – *rdo*

- `C-y` → `[/]`

Position symmetrical to Arsenik’s existing *ndo*.