### PR TITLE
feat(kanata): Use C-ins/S-ins for copy/paste

### DIFF
--- a/kanata/defalias/azerty_pc.kbd
+++ b/kanata/defalias/azerty_pc.kbd
@@ -9,8 +9,6 @@
   cls C-z
   ndo C-w
   cut C-x
-  cpy C-c
-  pst C-v
 
   0 S-0
   1 S-1

--- a/kanata/defalias/bepo_pc.kbd
+++ b/kanata/defalias/bepo_pc.kbd
@@ -8,8 +8,6 @@
   cls C-]
   ndo C-[
   cut C-c
-  cpy C-h
-  pst C-u
 
   0 S-0
   1 S-1

--- a/kanata/defalias/common.kbd
+++ b/kanata/defalias/common.kbd
@@ -1,0 +1,5 @@
+(defalias
+  ;; Copy/paste, TypeMatrix style
+  cpy C-ins
+  pst S-ins
+)

--- a/kanata/defalias/ergol_pc.kbd
+++ b/kanata/defalias/ergol_pc.kbd
@@ -8,8 +8,6 @@
   cls C-t
   ndo C-z
   cut C-x
-  cpy C-w
-  pst C-v
 
   0 0
   1 1

--- a/kanata/defalias/optimot_pc.kbd
+++ b/kanata/defalias/optimot_pc.kbd
@@ -8,8 +8,6 @@
   cls C-v
   ndo C-]
   cut C-[
-  cpy C-m
-  pst C-/
 
   0 S-0
   1 S-1

--- a/kanata/defalias/qwerty-lafayette_pc.kbd
+++ b/kanata/defalias/qwerty-lafayette_pc.kbd
@@ -8,8 +8,6 @@
   cls C-w
   ndo C-z
   cut C-x
-  cpy C-c
-  pst C-v
 
   0 0
   1 1

--- a/kanata/defalias/qwerty_mac.kbd
+++ b/kanata/defalias/qwerty_mac.kbd
@@ -8,8 +8,6 @@
   cls M-w
   ndo M-z
   cut M-x
-  cpy M-c
-  pst M-v
 
   0 0
   1 1

--- a/kanata/defalias/qwerty_pc.kbd
+++ b/kanata/defalias/qwerty_pc.kbd
@@ -9,8 +9,6 @@
   cls C-w
   ndo C-z
   cut C-x
-  cpy C-c
-  pst C-v
 
   0 0
   1 1

--- a/kanata/defalias/qwertz_pc.kbd
+++ b/kanata/defalias/qwertz_pc.kbd
@@ -9,8 +9,6 @@
   cls C-w
   ndo C-y
   cut C-x
-  cpy C-c
-  pst C-v
 
   0 0
   1 1

--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -91,4 +91,6 @@
   windows-altgr cancel-lctl-press
 )
 
+(include defalias/common.kbd)  ;; Cross-layout aliases
+
 ;; vim: set ft=lisp


### PR DESCRIPTION
Rationale: those shortcuts are shell-friendly, unlike C-c/C-v.