### PR TITLE
style(kanata): use key symbols

### DIFF
--- a/kanata/deflayer/base_lt_hrm.kbd
+++ b/kanata/deflayer/base_lt_hrm.kbd
@@ -3,7 +3,7 @@
 (deflayer base
   _    _    _    _    _    _    _    _    _    _    _
   q    w    e    r    t         y    u    i    o    p
-  a    @ss  @dd  @ff  g         h    @jj  @kk  @ll  ;
+  a    @s◆  @d⎈  @f⌥  g         h    @j⌥  @k⎈  @l◆  ;
   z    x    c    v    b    <    n    m    ,    .    /
             @sft          @nav            @sym
 )
@@ -20,12 +20,12 @@
   sym (tap-hold-press $tap_timeout $hold_timeout ret (layer-while-held symbols))
 
   ;; Home-row mods
-  ss (tap-hold $tap_timeout $long_hold_timeout s lmet)
-  dd (tap-hold $tap_timeout $long_hold_timeout d lctl)
-  ff (tap-hold $tap_timeout $long_hold_timeout f lalt)
-  jj (tap-hold $tap_timeout $long_hold_timeout j lalt)
-  kk (tap-hold $tap_timeout $long_hold_timeout k rctl)
-  ll (tap-hold $tap_timeout $long_hold_timeout l rmet)
+  s◆ (tap-hold $tap_timeout $long_hold_timeout s lmet)
+  d⎈ (tap-hold $tap_timeout $long_hold_timeout d lctl)
+  f⌥ (tap-hold $tap_timeout $long_hold_timeout f lalt)
+  j⌥ (tap-hold $tap_timeout $long_hold_timeout j lalt)
+  k⎈ (tap-hold $tap_timeout $long_hold_timeout k rctl)
+  l◆ (tap-hold $tap_timeout $long_hold_timeout l rmet)
 )
 
 ;; vim: set ft=lisp

--- a/kanata/deflayer/navigation.kbd
+++ b/kanata/deflayer/navigation.kbd
@@ -8,10 +8,10 @@
 
 (deflayer navigation
   M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
-  tab  home up   end  pgup      @/   @7   @8   @9   @run
-  @all lft  down rght pgdn      @-   @4   @5   @6   @0
-  @ndo @cut @cpy @pst S-tab _   @,   @1   @2   @3   @.
-            del             _             esc
+  ↹    ↖    ▲    ↘    ⇞         @/   @7   @8   @9   @run
+  @all ◀    ▼    ▶    ⇟         @-   @4   @5   @6   @0
+  @ndo @cut @cpy @pst S-↹   _   @,   @1   @2   @3   @.
+            ⌫               _             ⎋
 )
 
 ;; vim: set ft=lisp

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -8,17 +8,17 @@
 
 (deflayer navigation
   M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
-  @pad @cls bck  fwd  XX        home pgdn pgup end  @run
-  @all @sav S-tab tab XX        lft  down up   rght @fun
+  @pad @cls bck  fwd  XX        ↖    ⇟    ⇞    ↘    @run
+  @all @sav S-↹  ↹    XX        ◀    ▼    ▲    ▶    @fun
   @ndo @cut @cpy @pst XX    _   @mwl @mwd @mwu @mwr XX
-            del             _             esc
+            ⌦               _             ⎋
 )
 
 ;; NumPad
 (deflayer numpad
   _    _    _    _    _     _   _    _    _    _    _
-  XX   home up   end  pgup      @/   @7   @8   @9   XX
-  XX   lft  down rght pgdn      @-   @4   @5   @6   @0
+  XX   ↖    ▲    ↘    ⇞         @/   @7   @8   @9   XX
+  XX   ◀    ▼    ▶    ⇟         @-   @4   @5   @6   @0
   XX   XX   XX   XX   XX    _   @,   @1   @2   @3   @.
             @std           @nbs           @std
 )
@@ -27,7 +27,7 @@
 (deflayer funpad
   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX
   f1   f2   f3   f4   XX        XX   XX   XX   XX   XX
-  f5   f6   f7   f8   XX        XX   lctl lalt lmet _
+  f5   f6   f7   f8   XX        XX   ‹⎈   ‹⌥   ‹◆   _
   f9   f10  f11  f12  XX   XX   XX   XX   XX   XX   XX
             _               _             _
 )


### PR DESCRIPTION
Fancy symbols to help you memorize Arsenik’s layers 😎 

I’m actually not so sure this is a good idea; sure, having clear symbols show up in Kanata’s logs can help newcomers, but I’d argue this is helpful for a limited time thanks to muscular memory.  
Furthermore, these symbols are not so easy to handle with a text editor so I’m afraid it would do more harm to DX than good to beginners in the end.

Tell me what you think! 🙂 