### PR TITLE
navigation vim: lock fn layer

### DIFF
--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -29,14 +29,14 @@
   f1   f2   f3   f4   XX        XX   XX   XX   XX   XX
   f5   f6   f7   f8   XX        XX   lctl lalt lmet _
   f9   f10  f11  f12  XX   XX   XX   XX   XX   XX   XX
-            _               _             _
+            @std           _              @std
 )
 
 (defalias
   std (layer-switch base)
-  pad (layer-switch numpad)
 
-  fun (layer-while-held funpad)
+  pad (layer-switch numpad)
+  fun (layer-switch funpad)
 
   ;; Mouse wheel emulation
   mwu (mwheel-up    50 120)


### PR DESCRIPTION
The documentation said the Fn layer should be locked : https://github.com/OneDeadKey/arsenik/blob/d433298231b9c6ca4ea7bacf41c2b3dbc23a14f1/README.md?plain=1#L147-L148
This PR fix the config to match the doc.

But I prefer than this PR #50!