### PR TITLE
wip(kanata): add HRM-optimized navigation layer

### DIFF
--- a/kanata/deflayer/navigation_vim_hrm.kbd
+++ b/kanata/deflayer/navigation_vim_hrm.kbd
@@ -1,0 +1,64 @@
+;; Vim-Navigation layer (optimized for home-row mods):
+;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll
+;;  - left: TODO, Tab/Shift-Tab, prev/next
+;;  - top: Super-num (i3/sway) or Alt-num (browser), zoom in/out
+
+;; The `lrld` action stands for "live reload". This will re-parse everything
+;; except for linux-dev, i.e. you cannot live reload and switch keyboard devices.
+
+;; S-tab/tab on [W]/[E]
+;;  + strong fingers
+;;  + easy M-tab
+;;  - hard C-tab
+
+;; S-tab/tab on [A]/[S]
+;;  + homerow
+;;  + easy C-S-tab
+;;  - weak fingers
+;;  - hard M-tab
+
+;; S-tab/tab on [S]/[D]
+;;  + strong fingers
+;;  + homerow
+;;  - impossible C-tab
+
+(deflayer navigation
+  M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
+  @pad S-tab tab XX   XX        home pgdn pgup end  @run
+  XX   XX   bck  fwd  XX        lft  down up   rght @fun
+  XX   XX   XX   XX   XX    _   @mwl @mwd @mwu @mwr XX
+            del             _             esc
+)
+
+;; NumPad
+(deflayer numpad
+  _    _    _    _    _     _   _    _    _    _    _
+  XX   home up   end  pgup      @/   @7   @8   @9   XX
+  XX   lft  down rght pgdn      @-   @4   @5   @6   @0
+  XX   XX   XX   XX   XX    _   @,   @1   @2   @3   @.
+            @std           @nbs           @std
+)
+
+;; function keys
+(deflayer funpad
+  XX   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX
+  f1   f2   f3   f4   XX        XX   XX   XX   XX   XX
+  f5   f6   f7   f8   XX        XX   XX   XX   XX   _
+  f9   f10  f11  f12  XX   XX   XX   XX   XX   XX   XX
+            _               _             _
+)
+
+(defalias
+  std (layer-switch base)
+  pad (layer-switch numpad)
+
+  fun (layer-while-held funpad)
+
+  ;; Mouse wheel emulation
+  mwu (mwheel-up    50 120)
+  mwd (mwheel-down  50 120)
+  mwl (mwheel-left  50 120)
+  mwr (mwheel-right 50 120)
+)
+
+;; vim: set ft=lisp

--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -59,6 +59,7 @@
 
 (include deflayer/navigation.kbd)  ;; ESDF on the left, NumPad on the right
 ;; (include deflayer/navigation_vim.kbd)  ;; HJKL + NumPad on [Space]+[Q]
+;; (include deflayer/navigation_vim_hrm.kbd)  ;; HJKL + NumPad on [Space]+[Q], optimized for home-row mods
 
 ;; Replace XX by the keyboard shortcut of your application launcher, if any.
 ;; Mapped on [Space]+[P] in both navigation layers.


### PR DESCRIPTION
In the navigation layer, `WASZXCV` shortcuts are useful for some layouts, but they dramatically reduce the amount of good spots for other keys, such as `tab` and `S-tab`.

These are particularly useful with `Ctrl` and `Alt`, but their current position makes it difficult to press, say `Alt-tab` using home-row mods.

What if we keep extending Arsenik by adding a navigation layer built for HRM, losing the Qwerty shortcuts in the same process?