### PR TITLE
fix(ergol-kanata): CapsLock-related bugs

### DIFF
--- a/drivers/ergol-kanata/README.md
+++ b/drivers/ergol-kanata/README.md
@@ -2,13 +2,16 @@
 
 An Ergo-L "portable" driver, emulated with Kanata over your regular keymap.
 
+## Prerequisites
+
+Kanata v1.7.0+ is required.
+
 ## Caveats
 
 - Only Windows is supported at this point; this *doesn’t work* on GNU/Linux
   (yet?) and is untested on macOS.
 - Only Azerty-FR is supported as the base keymap at this point.
 - Mac keyboards are not supported at this point.
-- CapsLock can have unexpected behaviour, please report bugs.
 - Not all the dead keys on the AltGr-Shift layer are implemented yet.
 - Some other exotic characters may be missing, please report bugs.
 - Layer taps are not supported at this point.

--- a/drivers/ergol-kanata/defalias_azerty_pc.kbd
+++ b/drivers/ergol-kanata/defalias_azerty_pc.kbd
@@ -26,43 +26,6 @@
   . S-,
 )
 
-;; Symbols layer
-(defalias
-
-  ^  (macro [ spc)
-  <  <
-  >  S-<
-  $  ]
-  %  S-'
-  @  AG-0
-  &  1
-  *  \
-  '  4
-  `  (macro AG-7 spc)
-
-  {  AG-4
-  pl 5
-  pr -
-  }  AG-=
-  =  =
-  \  AG-8
-  +  S-=
-  -  6
-  /  S-.
-  '' 3
-
-  ~  (macro AG-2 spc)
-  [  AG-5
-  ]  AG--
-  _  8
-  #  AG-3
-  |  AG-6
-  !  /
-  ;  ,
-  :  .
-  ?  S-m
-)
-
 ;; NumRow layer
 (defalias
 

--- a/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
+++ b/drivers/ergol-kanata/deflayer_base_over_azerty.kbd
@@ -47,7 +47,7 @@
   ;; right-hand "extras"
   brk1 (t! dk-sft [ {)
   brk2 (t! dk-sft ] })
-  qte (fork 4 (unshift 3) (lsft rsft))  ;; '  "
+  qte (t! dk-sft ' r#"""#)  ;; '  "
   bksl (t! dk-sft \ |)
 
   ;; lower row
@@ -58,10 +58,10 @@
 
 ;; sft0
 (defalias
-  ?sft m
-  !sft (unshift /)
-  ;sft (unshift ,)
-  :sft (unshift .)
+  ?sft (unicode ?)
+  !sft (unicode !)
+  ;sft (unicode ;)
+  :sft (unicode :)
 )
 
 ;; Dead key layer 1
@@ -82,7 +82,7 @@
   Œ (t! dk-sft œ Œ)
   Ô (t! dk-sft ô Ô)
   µ (fork (unicode µ) XX (lsft rsft))
-  _dk (unshift 8)
+  _dk (unicode _)
   Û (t! dk-sft û Û)
 
   À (t! dk-sft à À)
@@ -90,8 +90,8 @@
   È (t! dk-sft è È)
   Ê (t! dk-sft ê Ê)
   Ñ (t! dk-sft ñ Ñ)
-  lpar (fork 5 XX (lsft rsft))
-  rpar (fork - XX (lsft rsft))
+  lpar (unicode r#"("#)  ;; (
+  rpar (unicode r#")"#)  ;; )
   Î (t! dk-sft î Î)
   Ï (t! dk-sft ï Ï)
   Ù (t! dk-sft ù Ù)

--- a/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
+++ b/drivers/ergol-kanata/deflayer_symbols_lafayette.kbd
@@ -15,6 +15,39 @@
   ₈ (unicode ₈)
   ₉ (unicode ₉)
   ₀ (unicode ₀)
+
+  ^ (unicode ^)
+  < (unicode <)
+  > (unicode >)
+  $ (unicode $)
+  % (unicode %)
+  @ (unicode @)
+  & (unicode &)
+  * (unicode *)
+  ' (unicode ')
+  ` (unicode `)
+
+  { (unicode {)
+  pl (unicode r#"("#)  ;; (
+  pr (unicode r#")"#)  ;; )
+  } (unicode })
+  = (unicode =)
+  \ (unicode \)
+  + (unicode +)
+  - (unicode -)
+  / (unicode /)
+  '' (unicode r#"""#)  ;; "
+
+  ~ (unicode ~)
+  [ (unicode [)
+  ] (unicode ])
+  _ (unicode _)
+  # (unicode #)
+  | (unicode |)
+  ! (unicode !)
+  ; (unicode ;)
+  : (unicode :)
+  ? (unicode ?)
 )
 
 ;; shifted symbols layer aliases


### PR DESCRIPTION
Fix bugs on some keys when CapsLock is enabled by using the `unicode` function throughout, instead of aliasing keys from the base layout.

This also increases portability to non-AZERTY system keymaps, as the non-base layers are now completely keymap-agnostic.

NB The `unicode` function works with the parenthesis and double quote characters only starting with Kanata 1.7.0.