### PR TITLE
fix(qmk): swap thumb layers

### DIFF
--- a/qmk/arsenik.h
+++ b/qmk/arsenik.h
@@ -62,14 +62,14 @@
 #elif defined ARSENIK_ENABLE_SELENIUM_VARIANT
 #    define AS_TL_REACH XX
 #    define AS_TR_REACH XX
-#    define AS_TL_TUCK  LT(_vim_nav, KC_ESC)
-#    define AS_TR_TUCK  LT(_num_row, KC_ENT)
+#    define AS_TL_TUCK  LSFT_T(KC_ESC)
+#    define AS_TR_TUCK  LAFAYETTE_T(KC_ENT)
 #    if defined SELENIUM_LEFT_HAND_SPACE
-#        define AS_TL_HOME  LSFT_T(KC_SPC)
-#        define AS_TR_HOME  LAFAYETTE_T(KC_BSPC)
+#        define AS_TL_HOME  LT(_vim_nav, KC_SPC)
+#        define AS_TR_HOME  LT(_num_row, KC_BSPC)
 #    else
-#        define AS_TL_HOME  LSFT_T(KC_BSPC)
-#        define AS_TR_HOME  LAFAYETTE_T(KC_SPC)
+#        define AS_TL_HOME  LT(_vim_nav, KC_BSPC)
+#        define AS_TR_HOME  LT(_num_row, KC_SPC)
 #    endif
 #else
 #    define AS_TL_TUCK LSFT_T(KC_BSPC)


### PR DESCRIPTION
It seems that the more important layers such as `Nav` and `Num` should be on the home position of the thumbs (as on [the slides of Arsenik’s presentation](https://fabi1cazenave.github.io/slides/2024-cdl/#52)). This PR aims to fix this by swapping the thumb layers. Feel free to close if I misunderstood anything and the current layers are the intended ones.