### PR TITLE
fix: kanata definition of the fn layer does not follow documentation

### DIFF
--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -27,16 +27,15 @@
 (deflayer funpad
   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX
   f1   f2   f3   f4   XX        XX   XX   XX   XX   XX
-  f5   f6   f7   f8   XX        XX   lctl lalt lmet _
+  f5   f6   f7   f8   XX        XX   lalt lctl lmet _
   f9   f10  f11  f12  XX   XX   XX   XX   XX   XX   XX
-            _               _             _
+            @std               _             @std
 )
 
 (defalias
   std (layer-switch base)
   pad (layer-switch numpad)
-
-  fun (layer-while-held funpad)
+  fun (layer-switch funpad)
 
   ;; Mouse wheel emulation
   mwu (mwheel-up    50 120)


### PR DESCRIPTION
There are differences between what the documentation of the function layer describes and what the Kanata layout really does about it. This commit should fix:

1. The function layer is now locked
2. Pressing lalt or ralt result to a switch to base
3. lalt and lctl were swapped to match the order of the homerow

I realize 1&2 might have been on purpose in which case the issue is the documentation. I just wanted to provide with a quick fix if it was not the case.

In any event I feel like swapping lalt and lctl is a good thing as it should match the order of the homerows in my opinion.

I would be more than happy to discuss all of this.