### PR TITLE
kanata numpad: add operators

### DIFF
--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -19,7 +19,7 @@
   _    _    _    _    _     _   _    _    _    _    _
   XX   home up   end  pgup      @/   @7   @8   @9   XX
   XX   lft  down rght pgdn      @-   @4   @5   @6   @0
-  XX   XX   XX   XX   XX    _   @,   @1   @2   @3   @.
+  @/   @*   @-   @+   @=    _   @,   @1   @2   @3   @.
             @std           @nbs           @std
 )
 

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -17,9 +17,9 @@
 ;; NumPad
 (deflayer numpad
   _    _    _    _    _     _   _    _    _    _    _
-  XX   home up   end  pgup      @/   @7   @8   @9   XX
-  XX   lft  down rght pgdn      @-   @4   @5   @6   @0
-  @/   @*   @-   @+   @=    _   @,   @1   @2   @3   @.
+  XX   home up   end  pgup      @/   @7   @8   @9   @:
+  bspc lft  down rght pgdn      @-   @4   @5   @6   @0
+  XX   @%   @*   @+   @=    _   @,   @1   @2   @3   @.
             @std           @nbs           @std
 )
 


### PR DESCRIPTION
Hi,

For use in a calculator or spreadsheet, I would expect basic operators to be available. And numpad layer has enough space for those, so here is a simple proposition.