### PR TITLE
kanata: fix ft=lisp modeline not interpreted

### DIFF
--- a/kanata/defalias/azerty_pc.kbd
+++ b/kanata/defalias/azerty_pc.kbd
@@ -85,4 +85,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/bepo_pc.kbd
+++ b/kanata/defalias/bepo_pc.kbd
@@ -84,4 +84,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/ergol_pc.kbd
+++ b/kanata/defalias/ergol_pc.kbd
@@ -86,4 +86,4 @@
   dk5 (macro @1dk @5)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/optimot_pc.kbd
+++ b/kanata/defalias/optimot_pc.kbd
@@ -84,4 +84,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/qwerty-lafayette_pc.kbd
+++ b/kanata/defalias/qwerty-lafayette_pc.kbd
@@ -86,4 +86,4 @@
   dk5 (macro @1dk @5)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/qwerty_mac.kbd
+++ b/kanata/defalias/qwerty_mac.kbd
@@ -84,4 +84,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/qwerty_pc.kbd
+++ b/kanata/defalias/qwerty_pc.kbd
@@ -85,4 +85,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defalias/qwertz_pc.kbd
+++ b/kanata/defalias/qwertz_pc.kbd
@@ -85,4 +85,4 @@
   dk5 XX
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/base.kbd
+++ b/kanata/deflayer/base.kbd
@@ -8,4 +8,4 @@
             _              _              _
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/base_lt.kbd
+++ b/kanata/deflayer/base_lt.kbd
@@ -20,4 +20,4 @@
   sym (tap-hold-press $tap_timeout $hold_timeout ret (layer-while-held symbols))
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/base_lt_hrm.kbd
+++ b/kanata/deflayer/base_lt_hrm.kbd
@@ -28,4 +28,4 @@
   ll (tap-hold $tap_timeout $long_hold_timeout l rmet)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/navigation.kbd
+++ b/kanata/deflayer/navigation.kbd
@@ -14,4 +14,4 @@
             del             _             esc
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/navigation_vim.kbd
+++ b/kanata/deflayer/navigation_vim.kbd
@@ -45,4 +45,4 @@
   mwr (mwheel-right 50 120)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/symbols_lafayette.kbd
+++ b/kanata/deflayer/symbols_lafayette.kbd
@@ -11,4 +11,4 @@
 ;; Note: this requires kanata 0.5+ to work properly.
 ;; kanata 0.4 does not release Shift soon enough for this layer to work.
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/symbols_lafayette_num.kbd
+++ b/kanata/deflayer/symbols_lafayette_num.kbd
@@ -23,4 +23,4 @@
   num (layer-toggle numrow)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/symbols_noop.kbd
+++ b/kanata/deflayer/symbols_noop.kbd
@@ -11,4 +11,4 @@
             _             AG-spc          _
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/deflayer/symbols_noop_num.kbd
+++ b/kanata/deflayer/symbols_noop_num.kbd
@@ -26,4 +26,4 @@
   num (layer-toggle numrow)
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/mac.kbd
+++ b/kanata/defsrc/mac.kbd
@@ -8,4 +8,4 @@
             lmet          spc             rmet
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/mac_anglemod.kbd
+++ b/kanata/defsrc/mac_anglemod.kbd
@@ -8,4 +8,4 @@
             lmet          spc             rmet
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/mac_ansi_anglemod.kbd
+++ b/kanata/defsrc/mac_ansi_anglemod.kbd
@@ -8,4 +8,4 @@
             lmet          spc             rmet
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/mac_ansi_wide_anglemod.kbd
+++ b/kanata/defsrc/mac_ansi_wide_anglemod.kbd
@@ -11,4 +11,4 @@
             lmet          spc             rmet
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/mac_wide_anglemod.kbd
+++ b/kanata/defsrc/mac_wide_anglemod.kbd
@@ -11,4 +11,4 @@
             lmet          spc             rmet
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/pc.kbd
+++ b/kanata/defsrc/pc.kbd
@@ -8,4 +8,4 @@
             lalt          spc             ralt
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/pc_anglemod.kbd
+++ b/kanata/defsrc/pc_anglemod.kbd
@@ -8,4 +8,4 @@
             lalt          spc             ralt
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/pc_ansi_anglemod.kbd
+++ b/kanata/defsrc/pc_ansi_anglemod.kbd
@@ -8,4 +8,4 @@
             lalt          spc             ralt
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/pc_ansi_wide_anglemod.kbd
+++ b/kanata/defsrc/pc_ansi_wide_anglemod.kbd
@@ -10,4 +10,4 @@
             lalt          spc             ralt
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/defsrc/pc_wide_anglemod.kbd
+++ b/kanata/defsrc/pc_wide_anglemod.kbd
@@ -10,4 +10,4 @@
             lalt          spc             ralt
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:

--- a/kanata/kanata.kbd
+++ b/kanata/kanata.kbd
@@ -91,4 +91,4 @@
   windows-altgr cancel-lctl-press
 )
 
-;; vim: set ft=lisp
+;; vim: set ft=lisp:


### PR DESCRIPTION
According to :help modeline, the modelines used in the kanata configuration files are considered a second type of modeline because of the use of an explicit `set` keyword.

Add a colon at the end of the modelines to have them be correctly interpreted by (neo)vim and have syntax highlighting working.

Closes: #103